### PR TITLE
Api schema validation

### DIFF
--- a/server/src/controllers/FormController.js
+++ b/server/src/controllers/FormController.js
@@ -1,13 +1,69 @@
 const router = require('express').Router();
+const Joi = require('joi');
 const FormRepository = require('../repositories/FormRepository');
 const { createSuccessResponse } = require('../utils');
 const { KNOWZONE_ERROR_TYPES, changeToCustomError } = require('../knowzoneErrorHandler');
 const { checkAuthentication } = require('../middlewares/checkAuthentication');
+const { FORM_SCHEMA_CONFIGS } = require('../models/schemaConfigs');
+const { hasObjectKey, isValidMaxNumKey } = require('../validators');
+const { isAnyInvalidKeyOrValue, isValidMaxNumImageComponent } = require('../models/formValidators');
+
+const { VALIDATION_MESSAGES, FORM_VALIDATION_MESSAGES } = require('../models/validationMessages');
 
 const formRepository = new FormRepository();
 
+const createSchema = Joi.object({
+  type: Joi
+    .string()
+    .max(FORM_SCHEMA_CONFIGS.MAX_LEN_TYPE)
+    .min(FORM_SCHEMA_CONFIGS.MIN_LEN_TYPE)
+    .required(),
+  content: Joi
+    .object()
+    .unknown()
+    .custom((content, helpers) => {
+      if (!hasObjectKey(content)) {
+        return helpers.message(
+          VALIDATION_MESSAGES.MIN_KEY('content', FORM_SCHEMA_CONFIGS.MIN_NUM_CONTENT),
+        );
+      }
+
+      if (!isValidMaxNumKey(content, FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT)) {
+        return helpers.message(
+          VALIDATION_MESSAGES.MAX_KEY('content', FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT),
+        );
+      }
+
+      if (isAnyInvalidKeyOrValue(content)) {
+        return helpers.message(
+          [
+            VALIDATION_MESSAGES.MIN_LEN('name'),
+            VALIDATION_MESSAGES.MAX_LEN('name', FORM_SCHEMA_CONFIGS.MAX_LEN_KEY_OF_CONTENT),
+            VALIDATION_MESSAGES.MIN_LEN('component type'),
+            FORM_VALIDATION_MESSAGES.INVALID_COMPONENT,
+          ].join('. '),
+        );
+      }
+
+      if (!isValidMaxNumImageComponent(content)) {
+        return helpers.message(FORM_VALIDATION_MESSAGES.MAX_IMAGE_COMPONENT);
+      }
+
+      return content;
+    })
+    .required(),
+}).required();
+
+const filterSchema = Joi.object({
+  fields: Joi.object(),
+  projection: [Joi.object(), Joi.string(), Joi.array().items(Joi.string())],
+  single: Joi.boolean(),
+});
+
 const create = async (req, res, next) => {
   try {
+    await createSchema.validateAsync(req.body);
+
     const form = req.body;
     form.owner = {
       id: req.session.userId,
@@ -61,6 +117,8 @@ const findById = async (req, res, next) => {
 
 const filter = async (req, res, next) => {
   try {
+    await filterSchema.validateAsync(req.body);
+
     let fields = { 'owner.id': req.session.userId };
 
     if (req.body?.fields) {

--- a/server/src/controllers/FormController.js
+++ b/server/src/controllers/FormController.js
@@ -5,9 +5,8 @@ const { createSuccessResponse } = require('../utils');
 const { KNOWZONE_ERROR_TYPES, changeToCustomError } = require('../knowzoneErrorHandler');
 const { checkAuthentication } = require('../middlewares/checkAuthentication');
 const { FORM_SCHEMA_CONFIGS } = require('../models/schemaConfigs');
-const { hasObjectKey, isValidMaxNumKey } = require('../validators');
-const { isAnyInvalidKeyOrValue, isValidMaxNumImageComponent } = require('../models/formValidators');
-
+const validators = require('../validators');
+const formValidators = require('../models/formValidators');
 const { VALIDATION_MESSAGES, FORM_VALIDATION_MESSAGES } = require('../models/validationMessages');
 
 const formRepository = new FormRepository();
@@ -22,19 +21,19 @@ const createSchema = Joi.object({
     .object()
     .unknown()
     .custom((content, helpers) => {
-      if (!hasObjectKey(content)) {
+      if (!validators.hasObjectMinNumKey(content)) {
         return helpers.message(
           VALIDATION_MESSAGES.MIN_KEY('content', FORM_SCHEMA_CONFIGS.MIN_NUM_CONTENT),
         );
       }
 
-      if (!isValidMaxNumKey(content, FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT)) {
+      if (!validators.isValidMaxNumKey(content, FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT)) {
         return helpers.message(
           VALIDATION_MESSAGES.MAX_KEY('content', FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT),
         );
       }
 
-      if (isAnyInvalidKeyOrValue(content)) {
+      if (formValidators.isAnyInvalidKeyOrValue(content)) {
         return helpers.message(
           [
             VALIDATION_MESSAGES.MIN_LEN('name'),
@@ -45,7 +44,7 @@ const createSchema = Joi.object({
         );
       }
 
-      if (!isValidMaxNumImageComponent(content)) {
+      if (!formValidators.isValidMaxNumImageComponent(content)) {
         return helpers.message(FORM_VALIDATION_MESSAGES.MAX_IMAGE_COMPONENT);
       }
 

--- a/server/src/controllers/FormController.js
+++ b/server/src/controllers/FormController.js
@@ -33,7 +33,7 @@ const createSchema = Joi.object({
         );
       }
 
-      if (formValidators.isAnyInvalidKeyOrValue(content)) {
+      if (!formValidators.isAllValidKeyValue(content)) {
         return helpers.message(
           [
             VALIDATION_MESSAGES.MIN_LEN('name'),

--- a/server/src/controllers/PostController.js
+++ b/server/src/controllers/PostController.js
@@ -54,6 +54,15 @@ const updateSchema = Joi.object({
           );
         }
 
+        if (!validators.isValidMaxLenKeys(content, FORM_SCHEMA_CONFIGS.MAX_LEN_KEY_OF_CONTENT)) {
+          return helper.message(
+            VALIDATION_MESSAGES.MAX_LEN(
+              'content field name',
+              FORM_SCHEMA_CONFIGS.MAX_LEN_KEY_OF_CONTENT,
+            ),
+          );
+        }
+
         if (!validators.isAnyFieldFilled(content)) {
           return helper.message('at least one content field must be filled');
         }

--- a/server/src/controllers/PostController.js
+++ b/server/src/controllers/PostController.js
@@ -1,15 +1,77 @@
 const router = require('express').Router();
+const Joi = require('joi');
 const PostRepository = require('../repositories/PostRepository');
-const { uploadImages, preparePostForCreate, preparePostForUpdate } = require('../middlewares/uploader');
+const {
+  uploadImages,
+  preparePostForCreate,
+  preparePostForUpdate,
+} = require('../middlewares/uploader');
 const { createSuccessResponse } = require('../utils');
 const { KNOWZONE_ERROR_TYPES, changeToCustomError } = require('../knowzoneErrorHandler');
 const { checkAuthentication } = require('../middlewares/checkAuthentication');
+const { FORM_SCHEMA_CONFIGS, POST_SCHEMA_CONFIGS } = require('../models/schemaConfigs');
+const { POST_VALIDATION_MESSAGES, VALIDATION_MESSAGES } = require('../models/validationMessages');
+const validators = require('../validators');
 
 const postRepository = new PostRepository();
+
+const typeSchemaPart = (
+  Joi.string()
+    .max(FORM_SCHEMA_CONFIGS.MAX_LEN_TYPE)
+    .message(VALIDATION_MESSAGES.MAX_LEN('type', FORM_SCHEMA_CONFIGS.MAX_LEN_TYPE))
+    .min(FORM_SCHEMA_CONFIGS.MIN_LEN_TYPE)
+    .message(VALIDATION_MESSAGES.MIN_LEN('type', FORM_SCHEMA_CONFIGS.MIN_LEN_TYPE))
+    .required()
+);
+
+const updateSchema = Joi.object({
+  topics: (
+    Joi.array()
+      .items(
+        Joi.string()
+          .regex(new RegExp(`^@?([a-z0-9-]){1,${POST_SCHEMA_CONFIGS.MAX_LEN_TOPIC}}$`))
+          .message(POST_VALIDATION_MESSAGES.INVALID_TOPIC),
+      )
+      .required()
+      .min(POST_SCHEMA_CONFIGS.MIN_NUM_TOPICS)
+      .message(VALIDATION_MESSAGES.MIN_NUM('topics', POST_SCHEMA_CONFIGS.MIN_NUM_TOPICS))
+      .max(POST_SCHEMA_CONFIGS.MAX_NUM_TOPICS)
+      .message(VALIDATION_MESSAGES.MAX_NUM('topics', POST_SCHEMA_CONFIGS.MAX_NUM_TOPICS))
+  ),
+  content: (
+    Joi.object()
+      .unknown()
+      .custom((content, helper) => {
+        if (!validators.hasObjectMinNumKey(content)) {
+          return helper.message(
+            VALIDATION_MESSAGES.MIN_KEY('content', FORM_SCHEMA_CONFIGS.MIN_NUM_CONTENT),
+          );
+        }
+
+        if (!validators.isValidMaxNumKey(content, FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT)) {
+          return helper.message(
+            VALIDATION_MESSAGES.MAX_KEY('content', FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT),
+          );
+        }
+
+        if (!validators.isAnyFieldFilled(content)) {
+          return helper.message('at least one content field must be filled');
+        }
+
+        return content;
+      })
+      .required()
+  ),
+  // This should not be validated. owner is added by the middleware.
+  owner: Joi.object(),
+}).required();
+
+const createSchema = updateSchema.keys({ type: typeSchemaPart });
 
 const create = async (_, res, next) => {
   try {
     const post = res.locals.data;
+    await createSchema.validateAsync(post);
     await postRepository.create(post);
     res.json(createSuccessResponse('Created the record successfully'));
   } catch (err) {
@@ -29,6 +91,8 @@ const findAll = async (req, res, next) => {
     const { userId } = req.session;
 
     if (type) {
+      await typeSchemaPart.validateAsync(type);
+
       res.send(await postRepository.find({ type, 'owner.id': userId }));
     } else {
       res.send(await postRepository.find({ 'owner.id': userId }));
@@ -63,7 +127,10 @@ const findById = async (req, res, next) => {
 
 const updateById = async (req, res, next) => {
   try {
+    await updateSchema.validateAsync(res.locals.data);
+
     const { content, ...rest } = res.locals.data;
+
     const post = await postRepository.findOne(
       { _id: req.params.id, 'owner.id': req.session.userId },
     );
@@ -75,6 +142,7 @@ const updateById = async (req, res, next) => {
     Object.entries(content ?? {}).forEach(([k, v]) => { post.content[k] = v; });
     Object.entries(rest ?? {}).forEach(([k, v]) => { post[k] = v; });
 
+    // TODO: Now, this might be redundant with latest mongoose version.
     post.markModified('content');
 
     res.json(await post.save());

--- a/server/src/middlewares/uploader.js
+++ b/server/src/middlewares/uploader.js
@@ -67,16 +67,14 @@ const createPostBody = (body, session) => {
 const getPathsOfUploadedFiles = (files) => {
   const images = [];
 
-  if (isAnyFileUploaded(files)) {
-    files.forEach((f) => {
-      const segments = f.path.split(path.sep);
+  files.forEach((f) => {
+    const segments = f.path.split(path.sep);
 
-      images.push({
-        name: f.originalname,
-        path: `${process.env.IMAGE_UPLOAD_SUBPATH}/${segments[segments.length - 1]}`,
-      });
+    images.push({
+      name: f.originalname,
+      path: `${process.env.IMAGE_UPLOAD_SUBPATH}/${segments[segments.length - 1]}`,
     });
-  }
+  });
 
   return images;
 };
@@ -86,7 +84,11 @@ const preparePostForCreate = (req, res, next) => {
   if (!data.content) {
     data.content = {};
   }
-  data.content.images = getPathsOfUploadedFiles(req.files);
+
+  if (isAnyFileUploaded(req.files)) {
+    data.content.images = getPathsOfUploadedFiles(req.files);
+  }
+
   res.locals.data = data;
 
   next();
@@ -94,9 +96,12 @@ const preparePostForCreate = (req, res, next) => {
 
 const mergeImages = (oldImages, newImageFiles) => {
   const oldImagePaths = oldImages ? JSON.parse(oldImages) : [];
-  const newImagePaths = getPathsOfUploadedFiles(newImageFiles);
 
-  return oldImagePaths.concat(newImagePaths);
+  if (isAnyFileUploaded(newImageFiles)) {
+    return oldImagePaths.concat(getPathsOfUploadedFiles(newImageFiles));
+  }
+
+  return oldImagePaths;
 };
 
 const isNoImageAfterUpdate = (oldImages) => (

--- a/server/src/models/Form.js
+++ b/server/src/models/Form.js
@@ -4,8 +4,8 @@ const owner = require('./Owner');
 const type = require('./Type');
 const { FORM_SCHEMA_CONFIGS } = require('./schemaConfigs');
 const { VALIDATION_MESSAGES, FORM_VALIDATION_MESSAGES } = require('./validationMessages');
-const { isObject, hasObjectKey, isValidMaxNumKey } = require('../validators');
-const { isAnyInvalidKeyOrValue, isValidMaxNumImageComponent } = require('./formValidators');
+const validators = require('../validators');
+const formValidators = require('./formValidators');
 
 const FormSchema = Schema(
   {
@@ -20,25 +20,25 @@ const FormSchema = Schema(
       validate: [
         {
           validator(content) {
-            return isObject(content);
+            return validators.isObject(content);
           },
           message: VALIDATION_MESSAGES.TYPE('content', 'object'),
         },
         {
           validator(content) {
-            return hasObjectKey(content);
+            return validators.hasObjectMinNumKey(content);
           },
           message: VALIDATION_MESSAGES.MIN_KEY('content', FORM_SCHEMA_CONFIGS.MIN_NUM_CONTENT),
         },
         {
           validator(content) {
-            return isValidMaxNumKey(content, FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT);
+            return validators.isValidMaxNumKey(content, FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT);
           },
           message: VALIDATION_MESSAGES.MAX_KEY('content', FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT),
         },
         {
           validator(content) {
-            return !isAnyInvalidKeyOrValue(content);
+            return !formValidators.isAnyInvalidKeyOrValue(content);
           },
           message: [
             VALIDATION_MESSAGES.MIN_LEN('name'),
@@ -49,7 +49,7 @@ const FormSchema = Schema(
         },
         {
           validator(content) {
-            return isValidMaxNumImageComponent(content);
+            return formValidators.isValidMaxNumImageComponent(content);
           },
           message: FORM_VALIDATION_MESSAGES.MAX_IMAGE_COMPONENT,
         },

--- a/server/src/models/Form.js
+++ b/server/src/models/Form.js
@@ -1,12 +1,11 @@
 const { Schema, model } = require('mongoose');
-const FORM_COMPONENT_TYPES = require('../constants/formComponentTypes');
 const { transformToJSON } = require('../utils');
 const owner = require('./Owner');
 const type = require('./Type');
 const { FORM_SCHEMA_CONFIGS } = require('./schemaConfigs');
 const { VALIDATION_MESSAGES, FORM_VALIDATION_MESSAGES } = require('./validationMessages');
-
-let numImageComponent = 0;
+const { isObject, hasObjectKey, isValidMaxNumKey } = require('../validators');
+const { isAnyInvalidKeyOrValue, isValidMaxNumImageComponent } = require('./formValidators');
 
 const FormSchema = Schema(
   {
@@ -20,39 +19,26 @@ const FormSchema = Schema(
       required: true,
       validate: [
         {
-          validator(v) {
-            return v !== null && typeof v === 'object' && !Array.isArray(v);
+          validator(content) {
+            return isObject(content);
           },
           message: VALIDATION_MESSAGES.TYPE('content', 'object'),
         },
         {
-          validator(v) {
-            return Object.keys(v).length;
+          validator(content) {
+            return hasObjectKey(content);
           },
           message: VALIDATION_MESSAGES.MIN_KEY('content', FORM_SCHEMA_CONFIGS.MIN_NUM_CONTENT),
         },
         {
-          validator(v) {
-            return Object.keys(v).length <= FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT;
+          validator(content) {
+            return isValidMaxNumKey(content, FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT);
           },
           message: VALIDATION_MESSAGES.MAX_KEY('content', FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT),
         },
         {
-          validator(v) {
-            numImageComponent = 0;
-            const isAnyInvalidKeyOrValue = Object.entries(v).some(([key, value]) => {
-              if (value === 'image') {
-                numImageComponent += 1;
-              }
-
-              return (
-                (typeof value !== 'string' || value.length === 0)
-                || (!Object.values(FORM_COMPONENT_TYPES).includes(value)
-                || (key.length > FORM_SCHEMA_CONFIGS.MAX_LEN_KEY_OF_CONTENT))
-              );
-            });
-
-            return !isAnyInvalidKeyOrValue;
+          validator(content) {
+            return !isAnyInvalidKeyOrValue(content);
           },
           message: [
             VALIDATION_MESSAGES.MIN_LEN('name'),
@@ -62,8 +48,8 @@ const FormSchema = Schema(
           ].join('. '),
         },
         {
-          validator() {
-            return numImageComponent <= FORM_SCHEMA_CONFIGS.MAX_IMAGE_COMP;
+          validator(content) {
+            return isValidMaxNumImageComponent(content);
           },
           message: FORM_VALIDATION_MESSAGES.MAX_IMAGE_COMPONENT,
         },

--- a/server/src/models/Form.js
+++ b/server/src/models/Form.js
@@ -38,7 +38,7 @@ const FormSchema = Schema(
         },
         {
           validator(content) {
-            return !formValidators.isAnyInvalidKeyOrValue(content);
+            return formValidators.isAllValidKeyValue(content);
           },
           message: [
             VALIDATION_MESSAGES.MIN_LEN('name'),

--- a/server/src/models/Post.js
+++ b/server/src/models/Post.js
@@ -1,97 +1,25 @@
 const { Schema, model, Error } = require('mongoose');
-const FORM_COMPONENT_TYPES = require('../constants/formComponentTypes');
-const { isArrayUnique, transformToJSON } = require('../utils');
+const { transformToJSON } = require('../utils');
 const Form = require('./Form');
 const owner = require('./Owner');
 const type = require('./Type');
 const { FORM_SCHEMA_CONFIGS, POST_SCHEMA_CONFIGS } = require('./schemaConfigs');
 const { VALIDATION_MESSAGES, POST_VALIDATION_MESSAGES } = require('./validationMessages');
+const validators = require('../validators');
+const postValidators = require('./postValidators');
 
-const validateMinNum = (name, min = 0) => ({
-  validator: (items) => items.length >= min,
-  message: VALIDATION_MESSAGES.MIN_NUM(name, min),
-});
+async function getFormOfPostOrInvalidate(post) {
+  const formRecord = await Form.findOne(
+    { type: post.type, 'owner.id': post.owner.id },
+    { type: 0, createdAt: 0, updatedAt: 0 },
+  );
 
-const validateMaxNum = (name, max = 0) => ({
-  validator: (items) => items.length <= max,
-  message: VALIDATION_MESSAGES.MAX_NUM(name, max),
-});
-
-const validateArrayUniqueness = () => ({
-  validator: (items) => isArrayUnique(items),
-  message: VALIDATION_MESSAGES.DUPLICATED_ITEMS,
-});
-
-const validateContentFields = (content, formRecord) => {
-  const formContent = Object.keys(formRecord.content);
-  const postContent = Object.keys(content);
-  const invalidFields = postContent.filter((f) => !formContent.includes(f));
-
-  if (invalidFields.length > 0) {
-    throw new Error(`${POST_VALIDATION_MESSAGES.INVALID_FIELD}: ${invalidFields.join(', ')}`);
+  if (!formRecord) {
+    throw new Error(VALIDATION_MESSAGES.NO_RECORD('form'));
   }
-};
 
-const validateValueOfContentFields = (content, formRecord) => {
-  const messages = [];
-  let isAnyInvalidValue = false;
-
-  Object.entries(content).forEach(([key, value]) => {
-    if (formRecord.content[key] === FORM_COMPONENT_TYPES.TEXT) {
-      if (value === null || typeof value === 'object' || Array.isArray(value)) {
-        messages.push(POST_VALIDATION_MESSAGES.VALUE(
-          key,
-          FORM_COMPONENT_TYPES.TEXT,
-          'string, number or boolean',
-        ));
-        isAnyInvalidValue = true;
-      }
-
-      if (value?.length > POST_SCHEMA_CONFIGS.MAX_LEN_TEXT) {
-        messages.push(VALIDATION_MESSAGES.MAX_LEN(key, POST_SCHEMA_CONFIGS.MAX_LEN_TEXT));
-        isAnyInvalidValue = true;
-      }
-
-      if (value?.length < POST_SCHEMA_CONFIGS.MIN_LEN_TEXT) {
-        messages.push(VALIDATION_MESSAGES.MIN_LEN(key, POST_SCHEMA_CONFIGS.MIN_LEN_TEXT));
-        isAnyInvalidValue = true;
-      }
-    } else if (formRecord.content[key] === FORM_COMPONENT_TYPES.LIST) {
-      if (!Array.isArray(value)) {
-        messages.push(POST_VALIDATION_MESSAGES.VALUE(key, FORM_COMPONENT_TYPES.LIST, 'array'));
-        isAnyInvalidValue = true;
-      }
-
-      if (value?.length > POST_SCHEMA_CONFIGS.MAX_NUM_LIST) {
-        messages.push(VALIDATION_MESSAGES.MAX_NUM(key, POST_SCHEMA_CONFIGS.MAX_NUM_LIST));
-        isAnyInvalidValue = true;
-      }
-    } else if (formRecord.content[key] === FORM_COMPONENT_TYPES.EDITOR) {
-      if (value === null || typeof value === 'object' || Array.isArray(value)) {
-        messages.push(POST_VALIDATION_MESSAGES.VALUE(
-          key,
-          FORM_COMPONENT_TYPES.EDITOR,
-          'string, number or boolean',
-        ));
-        isAnyInvalidValue = true;
-      }
-
-      if (value?.length > POST_SCHEMA_CONFIGS.MAX_LEN_EDITOR) {
-        messages.push(VALIDATION_MESSAGES.MAX_LEN(key, POST_SCHEMA_CONFIGS.MAX_LEN_EDITOR));
-        isAnyInvalidValue = true;
-      }
-
-      if (value?.length < POST_SCHEMA_CONFIGS.MIN_LEN_EDITOR) {
-        messages.push(VALIDATION_MESSAGES.MIN_LEN(key, POST_SCHEMA_CONFIGS.MIN_LEN_EDITOR));
-        isAnyInvalidValue = true;
-      }
-    }
-  });
-
-  if (isAnyInvalidValue) {
-    throw new Error(messages.join(', '));
-  }
-};
+  return formRecord;
+}
 
 const PostSchema = new Schema(
   {
@@ -111,9 +39,9 @@ const PostSchema = new Schema(
       ],
       required: true,
       validate: [
-        validateMinNum('topics', POST_SCHEMA_CONFIGS.MIN_NUM_TOPICS),
-        validateMaxNum('topics', POST_SCHEMA_CONFIGS.MAX_NUM_TOPICS),
-        validateArrayUniqueness(),
+        validators.validateMinNum('topics', POST_SCHEMA_CONFIGS.MIN_NUM_TOPICS),
+        validators.validateMaxNum('topics', POST_SCHEMA_CONFIGS.MAX_NUM_TOPICS),
+        validators.validateArrayUniqueness(),
       ],
     },
     content: {
@@ -121,41 +49,30 @@ const PostSchema = new Schema(
       required: true,
       validate: [
         {
-          validator(v) {
-            return v !== null && typeof v === 'object' && !Array.isArray(v);
+          validator(content) {
+            return validators.isObject(content);
           },
           message: VALIDATION_MESSAGES.TYPE('content', 'object'),
         },
         {
-          validator(v) {
-            return Object.keys(v).length <= FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT;
+          validator(content) {
+            return validators.isValidMaxNumKey(content, FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT);
           },
           message: VALIDATION_MESSAGES.MAX_KEY('content', FORM_SCHEMA_CONFIGS.MAX_NUM_CONTENT),
         },
         {
-          async validator(v) {
-            const formRecord = await Form.findOne(
-              { type: this.type, 'owner.id': this.owner.id },
-              { type: 0, createdAt: 0, updatedAt: 0 },
-            );
+          async validator(content) {
+            const formRecord = await getFormOfPostOrInvalidate(this);
 
-            if (!formRecord) {
-              throw new Error(VALIDATION_MESSAGES.NO_RECORD('form'));
-            }
-
-            if (!formRecord.content.images) {
-              delete v.images;
-            }
-
-            if (!Object.keys(v).length) {
+            if (!validators.hasObjectMinNumKey(content)) {
               throw new Error(
                 VALIDATION_MESSAGES.MIN_KEY('content', FORM_SCHEMA_CONFIGS.MIN_NUM_CONTENT),
               );
             }
 
-            validateContentFields(v, formRecord);
+            postValidators.validateContentFields(content, formRecord);
 
-            validateValueOfContentFields(v, formRecord);
+            postValidators.validateValueOfContentFields(content, formRecord);
 
             return true;
           },
@@ -171,7 +88,7 @@ const PostSchema = new Schema(
             },
           },
         ],
-        validate: validateMaxNum('images', POST_SCHEMA_CONFIGS.MAX_NUM_IMAGES),
+        validate: validators.validateMaxNum('images', POST_SCHEMA_CONFIGS.MAX_NUM_IMAGES),
       },
     },
   },

--- a/server/src/models/formValidators.js
+++ b/server/src/models/formValidators.js
@@ -1,0 +1,32 @@
+const FORM_COMPONENT_TYPES = require('../constants/formComponentTypes');
+const { FORM_SCHEMA_CONFIGS } = require('./schemaConfigs');
+
+function isAnyInvalidKeyOrValue(content) {
+  return Object.entries(content).some(([key, value]) => (
+    (typeof value !== 'string' || value.length === 0)
+      || (!Object.values(FORM_COMPONENT_TYPES).includes(value)
+      || (key.length > FORM_SCHEMA_CONFIGS.MAX_LEN_KEY_OF_CONTENT))
+  ));
+}
+
+function isValidMaxNumImageComponent(content) {
+  let numImageComponent = 0;
+  const contentValues = Object.values(content);
+
+  for (let i = 0; i < contentValues.length; i += 1) {
+    if (contentValues[i] === FORM_COMPONENT_TYPES.IMAGE) {
+      numImageComponent += 1;
+    }
+
+    if (numImageComponent > FORM_SCHEMA_CONFIGS.MAX_IMAGE_COMP) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+module.exports = {
+  isAnyInvalidKeyOrValue,
+  isValidMaxNumImageComponent,
+};

--- a/server/src/models/formValidators.js
+++ b/server/src/models/formValidators.js
@@ -1,11 +1,13 @@
 const FORM_COMPONENT_TYPES = require('../constants/formComponentTypes');
 const { FORM_SCHEMA_CONFIGS } = require('./schemaConfigs');
 
-function isAnyInvalidKeyOrValue(content) {
-  return Object.entries(content).some(([key, value]) => (
-    (typeof value !== 'string' || value.length === 0)
-      || (!Object.values(FORM_COMPONENT_TYPES).includes(value)
-      || (key.length > FORM_SCHEMA_CONFIGS.MAX_LEN_KEY_OF_CONTENT))
+function isAllValidKeyValue(content) {
+  return Object.entries(content).every(([key, value]) => (
+    typeof value === 'string'
+      && value.length > 0
+      && Object.values(FORM_COMPONENT_TYPES).includes(value)
+      && key.length > 0
+      && key.length <= FORM_SCHEMA_CONFIGS.MAX_LEN_KEY_OF_CONTENT
   ));
 }
 
@@ -27,6 +29,6 @@ function isValidMaxNumImageComponent(content) {
 }
 
 module.exports = {
-  isAnyInvalidKeyOrValue,
+  isAllValidKeyValue,
   isValidMaxNumImageComponent,
 };

--- a/server/src/models/postValidators.js
+++ b/server/src/models/postValidators.js
@@ -1,0 +1,96 @@
+const FORM_COMPONENT_TYPES = require('../constants/formComponentTypes');
+const { POST_SCHEMA_CONFIGS } = require('./schemaConfigs');
+const { POST_VALIDATION_MESSAGES, VALIDATION_MESSAGES } = require('./validationMessages');
+
+function validateContentFields(content, formRecord) {
+  const formContent = Object.keys(formRecord.content);
+  const postContent = Object.keys(content);
+  const invalidFields = postContent.filter((f) => !formContent.includes(f));
+
+  if (invalidFields.length > 0) {
+    throw new Error(`${POST_VALIDATION_MESSAGES.INVALID_FIELD}: ${invalidFields.join(', ')}`);
+  }
+}
+
+function validateTextValue(key, value) {
+  const messages = [];
+
+  if (value === null || typeof value === 'object' || Array.isArray(value)) {
+    messages.push(POST_VALIDATION_MESSAGES.VALUE(
+      key,
+      FORM_COMPONENT_TYPES.TEXT,
+      'string, number or boolean',
+    ));
+  }
+
+  if (value?.length > POST_SCHEMA_CONFIGS.MAX_LEN_TEXT) {
+    messages.push(VALIDATION_MESSAGES.MAX_LEN(key, POST_SCHEMA_CONFIGS.MAX_LEN_TEXT));
+  }
+
+  if (value?.length < POST_SCHEMA_CONFIGS.MIN_LEN_TEXT) {
+    messages.push(VALIDATION_MESSAGES.MIN_LEN(key, POST_SCHEMA_CONFIGS.MIN_LEN_TEXT));
+  }
+
+  return messages;
+}
+
+function validateListValue(key, value) {
+  const messages = [];
+
+  if (!Array.isArray(value)) {
+    messages.push(POST_VALIDATION_MESSAGES.VALUE(key, FORM_COMPONENT_TYPES.LIST, 'array'));
+  }
+
+  if (value?.length > POST_SCHEMA_CONFIGS.MAX_NUM_LIST) {
+    messages.push(VALIDATION_MESSAGES.MAX_NUM(key, POST_SCHEMA_CONFIGS.MAX_NUM_LIST));
+  }
+
+  return messages;
+}
+
+function validateEditorValue(key, value) {
+  const messages = [];
+
+  if (value === null || typeof value === 'object' || Array.isArray(value)) {
+    messages.push(
+      POST_VALIDATION_MESSAGES.VALUE(
+        key,
+        FORM_COMPONENT_TYPES.EDITOR,
+        'string, number or boolean',
+      ),
+    );
+  }
+
+  if (value?.length > POST_SCHEMA_CONFIGS.MAX_LEN_EDITOR) {
+    messages.push(VALIDATION_MESSAGES.MAX_LEN(key, POST_SCHEMA_CONFIGS.MAX_LEN_EDITOR));
+  }
+
+  if (value?.length < POST_SCHEMA_CONFIGS.MIN_LEN_EDITOR) {
+    messages.push(VALIDATION_MESSAGES.MIN_LEN(key, POST_SCHEMA_CONFIGS.MIN_LEN_EDITOR));
+  }
+
+  return messages;
+}
+
+function validateValueOfContentFields(content, formRecord) {
+  let messages = [];
+
+  Object.entries(content).forEach(([key, value]) => {
+    if (formRecord.content[key] === FORM_COMPONENT_TYPES.TEXT) {
+      messages = messages.concat(validateTextValue(key, value));
+    } else if (formRecord.content[key] === FORM_COMPONENT_TYPES.LIST) {
+      messages = messages.concat(validateListValue(key, value));
+    } else if (formRecord.content[key] === FORM_COMPONENT_TYPES.EDITOR) {
+      messages = messages.concat(validateEditorValue(key, value));
+    }
+  });
+
+  if (messages.length) {
+    throw new Error(messages.join(', '));
+  }
+}
+
+module.exports = {
+  validateContentFields,
+  validateValueOfContentFields,
+};

--- a/server/src/validators.js
+++ b/server/src/validators.js
@@ -1,17 +1,51 @@
+const { VALIDATION_MESSAGES } = require('./models/validationMessages');
+const { isArrayUnique } = require('./utils');
+
 function isObject(v) {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 
-function hasObjectKey(v) {
-  return Object.keys(v).length;
+function hasObjectMinNumKey(v, min = 0) {
+  return Object.keys(v).length && Object.keys(v).length > min;
 }
 
 function isValidMaxNumKey(v, max) {
   return Object.keys(v).length <= max;
 }
 
+function validateMinNum(name, min = 0) {
+  return {
+    validator: (items) => items.length >= min,
+    message: VALIDATION_MESSAGES.MIN_NUM(name, min),
+  };
+}
+
+function validateMaxNum(name, max = 0) {
+  return {
+    validator: (items) => items.length <= max,
+    message: VALIDATION_MESSAGES.MAX_NUM(name, max),
+  };
+}
+
+function validateArrayUniqueness() {
+  return {
+    validator: (items) => isArrayUnique(items),
+    message: VALIDATION_MESSAGES.DUPLICATED_ITEMS,
+  };
+}
+
+function isAnyFieldFilled(object) {
+  return Object.values(object).some(
+    (field) => (Array.isArray(field) ? field.length : field || false),
+  );
+}
+
 module.exports = {
   isObject,
-  hasObjectKey,
+  hasObjectMinNumKey,
   isValidMaxNumKey,
+  validateMinNum,
+  validateMaxNum,
+  validateArrayUniqueness,
+  isAnyFieldFilled,
 };

--- a/server/src/validators.js
+++ b/server/src/validators.js
@@ -1,0 +1,17 @@
+function isObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function hasObjectKey(v) {
+  return Object.keys(v).length;
+}
+
+function isValidMaxNumKey(v, max) {
+  return Object.keys(v).length <= max;
+}
+
+module.exports = {
+  isObject,
+  hasObjectKey,
+  isValidMaxNumKey,
+};

--- a/server/src/validators.js
+++ b/server/src/validators.js
@@ -40,6 +40,10 @@ function isAnyFieldFilled(object) {
   );
 }
 
+function isValidMaxLenKeys(object, max = 0) {
+  return Object.keys(object).every((k) => k?.length <= max);
+}
+
 module.exports = {
   isObject,
   hasObjectMinNumKey,
@@ -48,4 +52,5 @@ module.exports = {
   validateMaxNum,
   validateArrayUniqueness,
   isAnyFieldFilled,
+  isValidMaxLenKeys,
 };

--- a/server/test/middlewares/uploader.test.js
+++ b/server/test/middlewares/uploader.test.js
@@ -33,7 +33,6 @@ describe('uploader - preparePostForCreate', () => {
       content: {
         name: 'brown',
         surname: 'fox',
-        images: [],
       },
       owner: {
         id: '1',
@@ -53,9 +52,7 @@ describe('uploader - preparePostForCreate', () => {
     const result = {
       type: 'test type',
       topics: ['topic1', 'topic2'],
-      content: {
-        images: [],
-      },
+      content: {},
       owner: {
         id: '1',
         name: 'jack',

--- a/web/src/components/form/FormCreator.jsx
+++ b/web/src/components/form/FormCreator.jsx
@@ -10,6 +10,7 @@ import FileUploader from '../common/FileUploader';
 import MarkdownEditor from '../common/MarkdownEditor';
 import TagPicker from '../common/TagPicker/TagPicker';
 import formCreatorSchema from '../../schemas/formCreatorSchema';
+import { FORM_SCHEMA_CONFIGS } from '../../schemas/schemaConfigs';
 
 const PREFIX = 'FormCreator';
 
@@ -198,6 +199,7 @@ function MiddleContainer({ control, errors, getValues, watch }) {
                       size="small"
                       disabled={selectedImageComponentKey && selectedImageComponentKey === k}
                       name={name}
+                      inputProps={{ maxLength: FORM_SCHEMA_CONFIGS.MAX_LEN_KEY_OF_CONTENT }}
                     />
                   )}
                   control={control}

--- a/web/src/schemas/formCreatorSchema.js
+++ b/web/src/schemas/formCreatorSchema.js
@@ -13,6 +13,7 @@ const formCreatorSchema = Joi.object({
 
         Object.values(content).forEach((f) => {
           if (f.type === FORM_COMPONENT_TYPES.IMAGE) {
+            // TODO: can't we automate this process with setValue from react-hook-form
             contentKeys.push('images');
           } else if (f.name && f.type) {
             contentKeys.push(f.name);

--- a/web/src/schemas/formCreatorSchema.js
+++ b/web/src/schemas/formCreatorSchema.js
@@ -1,10 +1,17 @@
 import Joi from 'joi';
 import FORM_COMPONENT_TYPES from '../constants/form-components-types';
+import { FORM_SCHEMA_CONFIGS } from './schemaConfigs';
+import { VALIDATION_MESSAGES } from './validationMessages';
 
 const formCreatorSchema = Joi.object({
-  type:
+  type: (
     Joi.string()
-      .required(),
+      .max(FORM_SCHEMA_CONFIGS.MAX_LEN_TYPE)
+      .message(VALIDATION_MESSAGES.MAX_LEN('type', FORM_SCHEMA_CONFIGS.MAX_LEN_TYPE))
+      .min(FORM_SCHEMA_CONFIGS.MIN_LEN_TYPE)
+      .message(VALIDATION_MESSAGES.MIN_LEN('type', FORM_SCHEMA_CONFIGS.MIN_LEN_TYPE))
+      .required()
+  ),
   content:
     Joi.object()
       .unknown()

--- a/web/src/schemas/postCreatorSchema.js
+++ b/web/src/schemas/postCreatorSchema.js
@@ -1,40 +1,49 @@
 import Joi from 'joi';
-import { POST_SCHEMA_CONFIGS } from './schemaConfigs';
+import { FORM_SCHEMA_CONFIGS, POST_SCHEMA_CONFIGS } from './schemaConfigs';
+import { POST_VALIDATION_MESSAGES, VALIDATION_MESSAGES } from './validationMessages';
+import validators from './validators';
 
 const postCreatorSchema = Joi.object({
   id: Joi.string(),
   createdAt: Joi.string(),
   updatedAt: Joi.string(),
   owner: Joi.object(),
-  type:
+  type: (
     Joi.string()
-      .required(),
-  topics:
+      .max(FORM_SCHEMA_CONFIGS.MAX_LEN_TYPE)
+      .message(VALIDATION_MESSAGES.MAX_LEN('type', FORM_SCHEMA_CONFIGS.MAX_LEN_TYPE))
+      .min(FORM_SCHEMA_CONFIGS.MIN_LEN_TYPE)
+      .message(VALIDATION_MESSAGES.MIN_LEN('type', FORM_SCHEMA_CONFIGS.MIN_LEN_TYPE))
+      .required()
+  ),
+  topics: (
     Joi.array()
       .items(
         Joi.string()
           .regex(new RegExp(`^@?([a-z0-9-]){1,${POST_SCHEMA_CONFIGS.MAX_LEN_TOPIC}}$`))
-          .message(
-            [
-              `A topic should be at most ${POST_SCHEMA_CONFIGS.MAX_LEN_TOPIC}`,
-              'alphanumeric characters and it may also contain hyphen.',
-            ].join(' '),
-          ),
+          .message(POST_VALIDATION_MESSAGES.INVALID_TOPIC),
       )
       .required()
       .min(POST_SCHEMA_CONFIGS.MIN_NUM_TOPICS)
-      .message('at least one topic must be added')
-      .max(POST_SCHEMA_CONFIGS.MAX_NUM_TOPICS),
+      .message(VALIDATION_MESSAGES.MIN_NUM('topics', POST_SCHEMA_CONFIGS.MIN_NUM_TOPICS))
+      .max(POST_SCHEMA_CONFIGS.MAX_NUM_TOPICS)
+      .message(VALIDATION_MESSAGES.MAX_NUM('topics', POST_SCHEMA_CONFIGS.MAX_NUM_TOPICS))
+  ),
   content:
     Joi.object()
       .unknown()
       .custom((content, helper) => {
-        const isAnyFieldFilled = Object.values(content).some(
-          (field) => (Array.isArray(field) ? field.length : field || false),
-        );
-
-        if (!isAnyFieldFilled) {
+        if (!validators.isAnyFieldFilled(content)) {
           return helper.message('at least one content field must be filled');
+        }
+
+        if (!validators.isValidMaxLenKeys(content, FORM_SCHEMA_CONFIGS.MAX_LEN_KEY_OF_CONTENT)) {
+          return helper.message(
+            VALIDATION_MESSAGES.MAX_LEN(
+              'content field name',
+              FORM_SCHEMA_CONFIGS.MAX_LEN_KEY_OF_CONTENT,
+            ),
+          );
         }
 
         return content;

--- a/web/src/schemas/validationMessages.js
+++ b/web/src/schemas/validationMessages.js
@@ -1,0 +1,28 @@
+import FORM_COMPONENT_TYPES from '../constants/form-components-types';
+import { POST_SCHEMA_CONFIGS } from './schemaConfigs';
+
+export const VALIDATION_MESSAGES = Object.freeze({
+  TYPE: (field, type) => `${field} must be ${type}`,
+  MIN_LEN: (field, len = 0) => `length of ${field} cannot be smaller than ${len}`,
+  MAX_LEN: (field, len) => `length of ${field} cannot be longer than ${len}`,
+  MIN_NUM: (field, num = 0) => `number of ${field} cannot be less than ${num}`,
+  MAX_NUM: (field, num) => `number of ${field} cannot be greater than ${num}`,
+  MIN_KEY: (field, num) => `${field} must have at least ${num} key`,
+  MAX_KEY: (field, num) => `${field} must have at most ${num} key`,
+  NO_RECORD: (field) => `${field} record not found for the given type`,
+  DUPLICATED_ITEMS: 'Array cannot have duplicated items',
+});
+
+export const FORM_VALIDATION_MESSAGES = Object.freeze({
+  MAX_IMAGE_COMPONENT: 'content must have at most one image component',
+  INVALID_COMPONENT: `Valid component types are: ${Object.values(FORM_COMPONENT_TYPES).join(', ')}`,
+});
+
+export const POST_VALIDATION_MESSAGES = Object.freeze({
+  VALUE: (field, comp, type) => `value of ${field} ${comp} must be ${type}`,
+  INVALID_FIELD: 'invalid fields for form type',
+  INVALID_TOPIC: [
+    `A topic should be at most ${POST_SCHEMA_CONFIGS.MAX_LEN_TOPIC}`,
+    'alphanumeric characters and it may also contain hyphen.',
+  ].join(' '),
+});

--- a/web/src/schemas/validators.js
+++ b/web/src/schemas/validators.js
@@ -1,0 +1,14 @@
+function isAnyFieldFilled(object) {
+  return Object.values(object).some(
+    (field) => (Array.isArray(field) ? field.length : field || false),
+  );
+}
+
+function isValidMaxLenKeys(object, max = 0) {
+  return Object.keys(object).every((k) => k?.length <= max);
+}
+
+export default {
+  isAnyFieldFilled,
+  isValidMaxLenKeys,
+};

--- a/web/src/test/components/post/PostCreator.test.js
+++ b/web/src/test/components/post/PostCreator.test.js
@@ -17,6 +17,8 @@ import {
   expectMuiDropdownHasSelectedValue,
 } from '../../utils';
 import postCreatorSchema from '../../../schemas/postCreatorSchema';
+import { VALIDATION_MESSAGES } from '../../../schemas/validationMessages';
+import { POST_SCHEMA_CONFIGS } from '../../../schemas/schemaConfigs';
 
 const server = setupServer(...api);
 
@@ -294,7 +296,7 @@ describe('PostCreator', () => {
     await expectMuiDropdownHasSelectedValue(/post type/i, type);
     expect(uploader.files[0]).toBe(file);
     await waitFor(() => expect(screen.getAllByRole('alert')).toHaveLength(1));
-    screen.getByText(/at least one topic must be added/i);
+    screen.getByText(VALIDATION_MESSAGES.MIN_NUM('topics', POST_SCHEMA_CONFIGS.MIN_NUM_TOPICS));
     expect(mockOnSubmit).not.toBeCalled();
 
     window.URL.createObjectURL.mockReset();


### PR DESCRIPTION
Form Layer
----
- We don't need to apply all the validations of backend schemas in the corresponding frontend schema.
- Since we get the form before we create a post from it, we can validate the values of content fields in frontend but this may be inefficient.
- We don't need to apply validations for the number of keys of content in FormCreator.jsx. The schema is bound to the react-hook-form and cannot exceed the maximum number when we submit it.
- In particular, there can be inefficiencies in frontend when we validate the content object in both FormCreator.jsx and PostCreator.jsx. We can get rid of some of the validation functions if this happens because we already have validations in the controller and collection layers.
- We don't need to check the values of content fields in FormCreator.jsx. They are bound to options in dropdowns as well.

Controller Layer
----
- We shouldn't hit the database in the controller layer when we validate the request data. We hit the database in the collection layer already for validation(e.g. Post.js queries forms collection).

Notes
----
- Moving each common validation function in validations.js into separate folders might be better. We can easily copy only the necessary functions(files) to frontend rather than comparing both validations.js files every time we have changes.