### PR TITLE
add graceful shutdown handlers

### DIFF
--- a/server/src/config/startDB.js
+++ b/server/src/config/startDB.js
@@ -2,6 +2,8 @@ import mongoose from 'mongoose';
 
 async function startDB() {
   try {
+    console.log('knowzone - mongodb\n----');
+    console.log('> trying to connect to the database...');
     await mongoose.connect(
       process.env.MONGODB_URI,
       {
@@ -9,9 +11,9 @@ async function startDB() {
         useUnifiedTopology: true,
       },
     );
-    console.log('Connected to the database!');
+    console.log('> connected to the database');
   } catch (err) {
-    console.log('Cannot connect to the database!', err);
+    console.log('> cannot connect to the database:', err.message);
     process.exit();
   }
 }


### PR DESCRIPTION
**success**

expected logs:

```
❯ npm run dev

> server@1.0.0 dev
> nodemon src/app.js

[nodemon] 2.0.22
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): *.*
[nodemon] watching extensions: js,mjs,json
[nodemon] starting `node src/app.js`
knowzone - mongodb
----
> trying to connect to the database...
> connected to the database
knowzone - backend
----
> creating the http server...
> http server is listening at http://localhost:8000
^C
> exiting backend...
> closing mongodb connections...
> closed mongodb connections

done
```

```
❯ npm start

> server@1.0.0 start
> node src/app.js

knowzone - mongodb
----
> trying to connect to the database...
> connected to the database
knowzone - backend
----
> creating the http server...
> http server is listening at http://localhost:8000
^C
> exiting backend...
> closing mongodb connections...
> closed mongodb connections

done
```

**fail**

Close the database and try to connect it with this modification:

```js
# in server/config/startDB

async function startDB() {
  try {
    console.log('knowzone - mongodb\n----');
    console.log('> trying to connect to the database...');
    await mongoose.connect(
      process.env.MONGODB_URI,
      {
        useNewUrlParser: true,
        useUnifiedTopology: true,
        serverSelectionTimeoutMS: 3000, // set timeout to 3 seconds to test fail over quickly
      },
    );
    console.log('> connected to the database');
  } catch (err) {
    console.log('> cannot connect to the database:', err.message);
    process.exit();
  }
}
```

expected logs:

```
❯ npm run dev

> server@1.0.0 dev
> nodemon src/app.js

[nodemon] 2.0.22
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): *.*
[nodemon] watching extensions: js,mjs,json
[nodemon] starting `node src/app.js`
knowzone - mongodb
----
> trying to connect to the database...
> cannot connect to the database: connect ECONNREFUSED 127.0.0.1:27017
[nodemon] clean exit - waiting for changes before restart
```

```
❯ npm start

> server@1.0.0 start
> node src/app.js

knowzone - mongodb
----
> trying to connect to the database...
> cannot connect to the database: connect ECONNREFUSED 127.0.0.1:27017
```

References

- [To get faster feedback on failed operations, you can reduce serverSelectionTimeoutMS to 5000 as shown below...](https://mongoosejs.com/docs/connections.html#error-handling)

closes #156 