### PR TITLE
fix error of navigating back to empty form

### DIFF
--- a/web/src/components/post/Post.jsx
+++ b/web/src/components/post/Post.jsx
@@ -158,7 +158,7 @@ function ListPart({ title, listItems }) {
   return (
     <PostBodySection title={title ?? 'List'}>
       <ul className={classes.list}>
-        {listItems.map((listItem) => (
+        {(listItems ?? []).map((listItem) => (
           <li key={listItem} className={classes.listItem}>{listItem}</li>
         ))}
       </ul>

--- a/web/src/components/post/Posts.jsx
+++ b/web/src/components/post/Posts.jsx
@@ -26,12 +26,14 @@ const ContentWrapperHeaderContainer = styled('div')(({ theme }) => ({
   zIndex: 100,
 }));
 
-function Posts({ title, form, posts, setPosts }) {
+function Posts({ title, formAndPosts, setPosts }) {
   const [openForUpdate, setOpenForUpdate] = useState(false);
   const [openForAdd, setOpenForAdd] = useState(false);
   const [openDialog, setOpenDialog] = useState(false);
   const [isLinearProgressModalOpen, setIsLinearProgressModalOpen] = useState(false);
   const [selectedPost, setSelectedPost] = useState();
+
+  const { form, posts } = formAndPosts ?? {};
 
   const handleClose = () => setOpenDialog(false);
 

--- a/web/src/pages/PostsByType.jsx
+++ b/web/src/pages/PostsByType.jsx
@@ -5,8 +5,11 @@ import getFormByType from '../api/forms/getFormByType';
 import getPostsByType from '../api/posts/getPostsByType';
 
 function PostsByType() {
-  const [form, setForm] = useState({});
-  const [posts, setPosts] = useState([]);
+  const [formAndPosts, setFormAndPosts] = useState({ form: {}, posts: [] });
+
+  const setPosts = (newPosts) => {
+    setFormAndPosts((prevState) => ({ ...prevState, posts: newPosts }));
+  };
 
   const { type } = useParams();
 
@@ -14,11 +17,14 @@ function PostsByType() {
     let isMounted = true;
 
     if (isMounted) {
-      const initializeForm = async () => {
-        const result = await getFormByType(type);
-        setForm(result);
+      const initialize = async () => {
+        const [formResult, postsResult] = await Promise.all([
+          getFormByType(type),
+          getPostsByType(type),
+        ]);
+        setFormAndPosts({ form: formResult, posts: postsResult });
       };
-      initializeForm();
+      initialize();
     }
 
     return function cleanup() {
@@ -26,23 +32,7 @@ function PostsByType() {
     };
   }, [type]);
 
-  useEffect(() => {
-    let isMounted = true;
-
-    if (isMounted) {
-      const initializePosts = async () => {
-        const data = await getPostsByType(type);
-        setPosts(data);
-      };
-      initializePosts();
-    }
-
-    return function cleanup() {
-      isMounted = false;
-    };
-  }, [type]);
-
-  return <Posts title={type} form={form} posts={posts} setPosts={setPosts} />;
+  return <Posts title={type} formAndPosts={formAndPosts} setPosts={setPosts} />;
 }
 
 export default PostsByType;


### PR DESCRIPTION
Initializing the form and posts states separately can cause two re-renders, potentially resulting in overlap between the two. For example, when navigating to an empty form, the form state may change while the posts state is non-empty in the same render cycle. Thus, it is necessary to move form and posts to single object state.

closes #194 